### PR TITLE
Feature: build pdf from markdown using pandoc & lualatex

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -3,7 +3,7 @@
 #
 language = sh
 
-INS_SRC = echo+ mk-ar mk-ar-merge mk-deb-buildarch mk-filelist \
+INS_SRC = echo+ mddeps mk-ar mk-ar-merge mk-deb-buildarch mk-filelist \
     mk-help mk-install mk-rpm-buildarch mk-rpm-files mk-toc \
     remake
 

--- a/bin/mddeps
+++ b/bin/mddeps
@@ -1,0 +1,79 @@
+#!/bin/sh
+#
+# MDDEPS --generate a dependecy file from a .md document
+#
+# Remarks:
+# This script generates a file containing the dependencies of a
+# markdown document. Dependencies are defined as all images that are
+# included as ![...](<image>) and any other files that are directly
+# included using the include-files lua filter. These are in fenced
+# code blocks ```{.include}<file>...```
+
+target=
+verbose=
+debug=
+
+usage()
+{
+    cat <<EOF
+mddeps --generate a list of dependencies in Makefile compatible syntax
+         output is generated to stdout; typical usage redirects to a
+         .d file
+
+Usage:
+    mddeps [options] markdown-file
+
+Options:
+    -t <file>    define the target of the make rule generated
+    -h           display this help text
+    -v           verbose output
+    -_           debug output
+EOF
+}
+
+log_message() {	printf "mddeps: ";	printf "$@"; printf "\n"; } >&2
+notice()      { log_message "$@"; }
+info()        { if [ "$verbose" -o "$debug" ]; then log_message "$@"; fi; }
+debug()       { if [ "$debug" ]; then log_message "$@"; fi; }
+error()       { notice "$@"; usage >&2; exit 2;}
+
+while getopts "t:hv_" c
+do
+    case $c in
+	t)  target="$OPTARG";;
+	v)  verbose=1 debug=;;
+	q)  verbose=  debug=;;
+	_)  verbose=1 debug=1;;
+	h|\?)  usage >&2
+	       exit 2;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+if [ -z "${target}" ]; then error "no target specified"; fi
+
+if [ -z "$1" ]; then error "no markdown-file specified"; fi
+
+if [ ! -f "$1" ]; then error 'file %s does not exist' "$1"; fi
+
+main()
+{
+    input=$1
+    debug 'input=%s' "$1"
+    deps=$(sed -n -e 's/[ \t]*\!\[.*\](\(.*\)).*/\1/p' \
+	       -e '/```{.include}/,/```/{/```{.include}/!{/```/!p;};}' \
+	       ${input})
+    debug 'deps=%s' "${deps}"
+    echo "${target}: ${input} \\"
+    for dep in ${deps}; do
+	echo "\t ${dep} \\"
+    done
+    echo "\n"
+    # create empty targets to avoid Make errors when files no longer exist
+    for dep in ${deps}; do
+	echo "${dep}: \n\n"
+    done
+}
+
+
+main "$@"

--- a/make/lang/Makefile
+++ b/make/lang/Makefile
@@ -3,7 +3,7 @@
 #
 MK_SRC = asciidoc.mk c++-library.mk c-library.mk cmd.mk c++.mk \
     c.mk conf.mk cron.mk cs.mk css.mk elisp.mk img.mk java.mk \
-    javascript.mk lex-library.mk lex.mk markdown.mk mk.mk \
+    javascript.mk lex-library.mk lex.mk markdown.mk md.mk mk.mk \
     nroff.mk perl.mk php.mk plantuml.mk protobuf-library.mk \
     protobuf.mk python.mk qt-library.mk qt.mk ruby.mk \
     sh.mk sql.mk tex.mk xml.mk xsd-library.mk vsproj.mk xsd.mk \

--- a/make/lang/md.mk
+++ b/make/lang/md.mk
@@ -1,0 +1,98 @@
+#
+# MD.MK --Rules for dealing with markdown files via pandoc.
+#
+# Contents:
+# %.pdf:          --Create a PDF document from a markdown file.
+# build:          --Create PDF documents from markdown.
+# clean-md:       --Clean up output
+# src-md:         --Update MD_SRC macro.
+# todo-md:        --Report unfinished work in markdown files.
+# +version:       --Report details of tools used by markdown.
+#
+# Remarks:
+# The md module uses pandoc as the underlying transformation engine
+# and is configured to use markdown+raw_attributes.
+#
+ The `src` target will update the makefile with the following macros:
+#
+# * MD_SRC --a list of the CommonMark/github-flavoured ".md" files
+#
+# See Also:
+# http://pandoc.org
+#
+.PHONY: $(recursive-targets:%=%-md)
+
+
+ifdef autosrc
+    LOCAL_MD_SRC := $(wildcard *.md)
+
+    MD_SRC ?= $(LOCAL_MD_SRC)
+endif
+
+MD ?= pandoc
+MD_PDF ?= lualatex
+
+PRINT_pandoc_VERSION = $(MD) --version
+PRINT_lualatex_VERSION = $(MD_PDF) --version
+
+ALL_MDFLAGS ?= -f markdown+raw_attribute \
+    $(OS.MDFLAGS) $(ARCH.MDFLAGS) $(PROJECT.MDFLAGS) \
+    $(LOCAL.MDFLAGS) $(TARGET.MDFLAGS) $(MDFLAGS)
+
+#
+# $(archdir)/%.pdf:%.md --build a PDF document from a markdown file.
+#
+$(archdir)/%.pdf: %.md $(gendir)/%.d | $(archdir) $(gendir)
+	$(ECHO_TARGET)
+	$(Q)$(MDDEPS) -t "$@" "$<" > $(gendir)/$*.d
+	$(MD) $(ALL_MDFLAGS) --pdf-engine=$(MD_PDF) -o $@ $<
+
+DEPFILES = $(MD_SRC:%.md=$(gendir)/%.d)
+$(DEPFILES):
+
+include $(wildcard $(DEPFILES))
+
+#
+# $(archdir)/%.tex:%md --generate a latex document from a markdown file
+#
+$(archdir)/%.tex: %.md | $(archdir)
+	$(ECHO_TARGET)
+	$(Q)$(MDDEPS) -t "$@" "$<" > $(gendir)/$*.d
+	$(MD) $(ALL_MDFLAGS) -t latex -o $@ $<
+
+#
+# build: --Create PDF documents from markdown.
+#
+build: build-md
+build-md: $(MD_SRC:%.md=$(archdir)/%.pdf)
+
+
+#
+# clean-md: --Clean up markdown's derived files.
+#
+distclean:	clean-md
+clean:	clean-md
+clean-md:
+	$(ECHO_TARGET)
+	$(RM) $(MD_SRC:%.md=$(archdir)/%.pdf)
+	$(RM) $(DEPFILES)
+
+#
+# src-md: --Update MD_SRC, MMD_SRC macros.
+#
+src:	src-md
+src-md:
+	$(ECHO_TARGET)
+	$(Q)$(MK-FILELIST) -f $(MAKEFILE) -qn MD_SRC *.md
+
+#
+# todo-md: --Report unfinished work in markdown files.
+#
+todo:	todo-md
+todo-md:
+	$(ECHO_TARGET)
+	@$(GREP) $(TODO_PATTERN) $(MD_SRC) $(MMD_SRC) /dev/null ||:
+#
+# +version: --Report details of tools used by markdown.
+#
++version: cmd-version[$(MD)] cmd-version[$(MD_PDF)]

--- a/make/makeshift-tools.mk
+++ b/make/makeshift-tools.mk
@@ -9,3 +9,4 @@ MK-RPM-BUILDARCH = $(MAKESHIFT_BIN)/mk-rpm-buildarch
 MK-RPM-FILES = $(MAKESHIFT_BIN)/mk-rpm-files
 MK-TOC = $(MAKESHIFT_BIN)/mk-toc
 REMAKE = $(MAKESHIFT_BIN)/remake
+MDDEPS = $(MAKESHIFT_BIN)/mddeps


### PR DESCRIPTION
Added markdown to pdf conversion via pandoc as opposed to prince as in upstream markdown.md
Added mddeps, a dependency generator tool that generates .d files for .md files